### PR TITLE
Feature/allow older ubuntu lts versions

### DIFF
--- a/ubuntu-lts.sh
+++ b/ubuntu-lts.sh
@@ -4,12 +4,24 @@ DIR=$(
   pwd
 )
 
-mapfile -t LTS_RELEASES < <(curl -s https://changelogs.ubuntu.com/meta-release-lts | grep "^Dist:" | awk '{print $2}')
+mapfile -t LTS_ENTRIES < <(
+  curl -s https://changelogs.ubuntu.com/meta-release-lts | awk '
+    /^Dist:/    { dist=$2 }
+    /^Version:/ { ver=$2; print dist " " ver }
+  ' | tail -4 | tac
+)
 
-if [ ${#LTS_RELEASES[@]} -eq 0 ]; then
+if [ ${#LTS_ENTRIES[@]} -eq 0 ]; then
   echo "Error: Could not fetch LTS release list from Ubuntu"
   exit 1
 fi
+
+LTS_RELEASES=()
+LTS_VERSIONS=()
+for entry in "${LTS_ENTRIES[@]}"; do
+  LTS_RELEASES+=("${entry%% *}")
+  LTS_VERSIONS+=("${entry##* }")
+done
 
 LAST_LTS_RELEASE="${LTS_RELEASES[-1]}"
 
@@ -21,22 +33,26 @@ if [ -n "$1" ]; then
   done
   if [ "$VALID" -eq 0 ]; then
     echo "Error: '$SELECTED_RELEASE' is not a valid LTS release."
-    echo "Available: ${LTS_RELEASES[*]}"
+    printf "Available: "
+    for i in "${!LTS_RELEASES[@]}"; do
+      printf "%s (%s)  " "${LTS_RELEASES[$i]}" "${LTS_VERSIONS[$i]}"
+    done
+    echo ""
     exit 1
   fi
 else
   echo ""
   echo "Available Ubuntu LTS versions:"
   for i in "${!LTS_RELEASES[@]}"; do
-    if [ "${LTS_RELEASES[$i]}" = "$SELECTED_RELEASE" ]; then
-      echo "  $((i+1))) ${LTS_RELEASES[$i]} (latest)"
+    if [ "${LTS_RELEASES[$i]}" = "$LAST_LTS_RELEASE" ]; then
+      echo "  $((i+1))) ${LTS_VERSIONS[$i]} (${LTS_RELEASES[$i]}) (latest)"
     else
-      echo "  $((i+1))) ${LTS_RELEASES[$i]}"
+      echo "  $((i+1))) ${LTS_VERSIONS[$i]} (${LTS_RELEASES[$i]})"
     fi
   done
   echo ""
-  read -rp "Select version [1-${#LTS_RELEASES[@]}, default: ${#LTS_RELEASES[@]}]: " SELECTION
-  SELECTION="${SELECTION:-${#LTS_RELEASES[@]}}"
+  read -rp "Select version [1-${#LTS_RELEASES[@]}, default: 1]: " SELECTION
+  SELECTION="${SELECTION:-1}"
   if ! [[ "$SELECTION" =~ ^[0-9]+$ ]] || [ "$SELECTION" -lt 1 ] || [ "$SELECTION" -gt "${#LTS_RELEASES[@]}" ]; then
     echo "Error: Invalid selection"
     exit 1

--- a/ubuntu-lts.sh
+++ b/ubuntu-lts.sh
@@ -1,13 +1,51 @@
 #!/bin/bash
-CURL_LAST_LTS_RELEASE=$(curl -s https://changelogs.ubuntu.com/meta-release-lts | grep Dist: | tail -n1)
-LAST_LTS_RELEASE=${CURL_LAST_LTS_RELEASE:6}
 DIR=$(
   cd "$(dirname "$0")" || exit 1
   pwd
 )
 
+mapfile -t LTS_RELEASES < <(curl -s https://changelogs.ubuntu.com/meta-release-lts | grep "^Dist:" | awk '{print $2}')
+
+if [ ${#LTS_RELEASES[@]} -eq 0 ]; then
+  echo "Error: Could not fetch LTS release list from Ubuntu"
+  exit 1
+fi
+
+LAST_LTS_RELEASE="${LTS_RELEASES[-1]}"
+
+if [ -n "$1" ]; then
+  SELECTED_RELEASE="$1"
+  VALID=0
+  for r in "${LTS_RELEASES[@]}"; do
+    [ "$r" = "$SELECTED_RELEASE" ] && VALID=1 && break
+  done
+  if [ "$VALID" -eq 0 ]; then
+    echo "Error: '$SELECTED_RELEASE' is not a valid LTS release."
+    echo "Available: ${LTS_RELEASES[*]}"
+    exit 1
+  fi
+else
+  echo ""
+  echo "Available Ubuntu LTS versions:"
+  for i in "${!LTS_RELEASES[@]}"; do
+    if [ "${LTS_RELEASES[$i]}" = "$SELECTED_RELEASE" ]; then
+      echo "  $((i+1))) ${LTS_RELEASES[$i]} (latest)"
+    else
+      echo "  $((i+1))) ${LTS_RELEASES[$i]}"
+    fi
+  done
+  echo ""
+  read -rp "Select version [1-${#LTS_RELEASES[@]}, default: ${#LTS_RELEASES[@]}]: " SELECTION
+  SELECTION="${SELECTION:-${#LTS_RELEASES[@]}}"
+  if ! [[ "$SELECTION" =~ ^[0-9]+$ ]] || [ "$SELECTION" -lt 1 ] || [ "$SELECTION" -gt "${#LTS_RELEASES[@]}" ]; then
+    echo "Error: Invalid selection"
+    exit 1
+  fi
+  SELECTED_RELEASE="${LTS_RELEASES[$((SELECTION-1))]}"
+fi
+
 echo ""
-echo "This script will download and setup an vm with the newest Ubuntu LTS Version ($LAST_LTS_RELEASE)"
+echo "This script will download and setup a VM with Ubuntu LTS: $SELECTED_RELEASE"
 echo ""
 
 if [ "$EUID" -ne 0 ]; then
@@ -21,8 +59,8 @@ if [ ! -f "$DIR/ssh-keys.pub" ]; then
   exit
 fi
 
-echo "Check and re-download Image $LAST_LTS_RELEASE-server-cloudimg-amd64.img if there is a newer img file"
-wget -N "https://cloud-images.ubuntu.com/$LAST_LTS_RELEASE/current/$LAST_LTS_RELEASE-server-cloudimg-amd64.img" -P /tmp/
+echo "Check and re-download Image $SELECTED_RELEASE-server-cloudimg-amd64.img if there is a newer img file"
+wget -N "https://cloud-images.ubuntu.com/$SELECTED_RELEASE/current/$SELECTED_RELEASE-server-cloudimg-amd64.img" -P /tmp/
 
 echo "Enter VM ID"
 read -r VM_ID
@@ -32,15 +70,15 @@ read -r VM_NAME
 echo "Ensure libguestfs-tools is installed"
 apt install libguestfs-tools -y
 
-echo "Create copy of $LAST_LTS_RELEASE-server-cloudimg-amd64 for image modification"
-cp -r "/tmp/$LAST_LTS_RELEASE-server-cloudimg-amd64.img" "/tmp/$LAST_LTS_RELEASE-server-cloudimg-amd64.modified.img"
+echo "Create copy of $SELECTED_RELEASE-server-cloudimg-amd64 for image modification"
+cp -r "/tmp/$SELECTED_RELEASE-server-cloudimg-amd64.img" "/tmp/$SELECTED_RELEASE-server-cloudimg-amd64.modified.img"
 
 echo "Install qemu-guest-agent on Ubuntu image"
-virt-customize -a "/tmp/$LAST_LTS_RELEASE-server-cloudimg-amd64.modified.img" --install qemu-guest-agent
+virt-customize -a "/tmp/$SELECTED_RELEASE-server-cloudimg-amd64.modified.img" --install qemu-guest-agent
 
 echo "Create Proxmox VM image from Ubuntu Cloud Image"
 qm create "$VM_ID" --memory 1024 --balloon 0 --cores 2 --net0 virtio,bridge=vmbr0 --scsihw virtio-scsi-pci
-qm set "$VM_ID" --scsi0 local-lvm:0,import-from="/tmp/$LAST_LTS_RELEASE-server-cloudimg-amd64.modified.img"
+qm set "$VM_ID" --scsi0 local-lvm:0,import-from="/tmp/$SELECTED_RELEASE-server-cloudimg-amd64.modified.img"
 qm set "$VM_ID" --agent enabled=1,fstrim_cloned_disks=1
 
 echo "Create Cloud-Init Disk and configure boot"
@@ -56,4 +94,4 @@ qm set "$VM_ID" \
   --ipconfig0 "ip=dhcp,ip6=dhcp"
 
 echo "Cleanup: delete modified cloudimg"
-rm -f "/tmp/$LAST_LTS_RELEASE-server-cloudimg-amd64.modified.img"
+rm -f "/tmp/$SELECTED_RELEASE-server-cloudimg-amd64.modified.img"


### PR DESCRIPTION
This features add a list to choose which LTS version should be installed. Newest version is always as default used.

Useful for MongoDB instances where currently Ubuntu 26.04 LTS ships an unsupported kernel for MongoDB.